### PR TITLE
fix: correct Faled→Failed typo in PixmapLoadError message

### DIFF
--- a/scientific_inkscape/inkex1_3_0/inkex/gui/pixmap.py
+++ b/scientific_inkscape/inkex1_3_0/inkex/gui/pixmap.py
@@ -310,7 +310,7 @@ class PixmapManager:
             loader.write(data)
             loader.close()
         except GLib.GError as err:
-            raise PixmapLoadError(f"Faled to load pixbuf from data: {err}")
+            raise PixmapLoadError(f"Failed to load pixbuf from data: {err}")
         return loader.get_pixbuf()
 
     def load_from_name(self, name):


### PR DESCRIPTION
Corrects the typo `Faled` → `Failed` in the PixmapLoadError message at line 313 of `scientific_inkscape/inkex1_3_0/inkex/gui/pixmap.py`.